### PR TITLE
Add ability to save both color and brightness to preset color swatches

### DIFF
--- a/src/components/LightCard.tsx
+++ b/src/components/LightCard.tsx
@@ -350,6 +350,7 @@ export const LightCard = (props: LightCardProps) => {
 
     async function handleSwatchClick(preset: Preset) {
         clickedSwatch.current = true
+        setBrightnessSliderValue(preset.brightness)
         await changeColor(preset.color)
         await changeBrightness(preset.brightness)
     }

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -111,7 +111,13 @@ export interface newBroadcast {
 export interface LightCardProps {
     light: goveeDeviceWithState,
 }
+
 export interface LightsGridProps {
     lights: goveeDeviceWithState[] | undefined,
     isLoading: boolean,
+}
+
+export interface Preset {
+    color: string,
+    brightness: number,
 }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react"
 
 // useState by setting and getting from localStorage.
-export function useLocalStorageState(key: string, defaultValue: any) {
+export function useLocalStorageState<T>(key: string, defaultValue: T): [T, (value: T) => void] {
     const [state, setState] = useState(() => {
         const valueInLocalStorage = localStorage.getItem(key)
         if (valueInLocalStorage) {


### PR DESCRIPTION
Rather than color swatches being based on the color hex values as strings, they're now based on an object of type Preset that contains the color and the brightness of the current state.

useLocalStorageState() now uses generic T for passing type to and from the hook for type safety.