### PR TITLE
Brightness slider fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,9 @@ export default function App() {
         () => getAvailableLights(),
         {
             staleTime: QueryConfig.staleTime,
+            refetchInterval: QueryConfig.refetchInterval,
+            refetchIntervalInBackground: true,
+            refetchOnWindowFocus: true,
         })
 
     // https://tanstack.com/query/v4/docs/guides/disabling-queries#isinitialloading

--- a/src/components/light-card/LightCard.tsx
+++ b/src/components/light-card/LightCard.tsx
@@ -221,6 +221,20 @@ export const LightCard = (props: LightCardProps) => {
         }
     }
 
+    // The problem here is we get light fetch updates from props, but we set the brightness value
+    // based on useState.
+    // This will synchronize brightness useState whenever light brightness props changes.
+    // This is a "temporary" solution since really we should not need to useEffect for
+    // synchronizing state with props. It's all internal.
+    // Then again, *technically* the updated state is coming from an external API update..
+    // TODO: Maybe something similar can be achieved with useMemo?
+    //   Probably the real solution is to rethink how we're managing state within react-query.
+    //   and handle light state at the global level, that way all we need to reference is props.
+    useEffect(() => {
+        setBrightnessSliderValue(props.light.status.brightness)
+
+    }, [props.light.status.brightness])
+
     // Effect for managing UI sync with websocket updates from other users.
     // Throttles the updates according to the NetworkConfig.socketUpdateRate.
     // https://stackoverflow.com/a/66616016/13627106

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,5 +31,5 @@ export class NetworkConfig {
 }
 export class QueryConfig {
     static staleTime = intervals.thirtySeconds
-    static refetchInterval = intervals.tenMinutes * 3
+    static refetchInterval = intervals.fiveMinutes
 }

--- a/src/utils/api/websocket-utilities.ts
+++ b/src/utils/api/websocket-utilities.ts
@@ -45,21 +45,22 @@ export const multiplayer = {
 }
 
 multiplayer.client.onopen = () => {
-    console.log("Socket established.")
-    try {
-        setInterval(() => {
+    // https://stackoverflow.com/a/24515576
+    function sendPing() {
+        try {
             if (multiplayer.client.readyState !== multiplayer.client.OPEN) {
                 multiplayer.client.close()
                 multiplayer.reconnect()
             }
             multiplayer.client.send("ping")
-        }, 5000)
+        }
+        catch (error) {
+            console.error("There was an error sending a ping to the server: ", error)
+            multiplayer.client.close()
+            multiplayer.reconnect()
+        }
     }
-    catch (error) {
-        console.error("There was an error sending a ping to the server: ", error)
-        multiplayer.client.close()
-        multiplayer.reconnect()
-    }
+    setInterval(sendPing, 5000)
 }
 multiplayer.client.onclose = () => {
     console.log("Websocket closed. Reconnecting...")


### PR DESCRIPTION
The problem here is we get light fetch updates from props, but we set the brightness value based on useState. 

This will synchronize brightness useState whenever light brightness props changes. This is a "temporary" solution since really we should not need to useEffect for synchronizing state with props. It's all internal. Then again, *technically* the updated state is coming from an external API update..

```ts
    useEffect(() => {
        setBrightnessSliderValue(props.light.status.brightness)

    }, [props.light.status.brightness])
```

TODO: Maybe something similar can be achieved with useMemo?
Probably the real solution is to rethink how we're managing state within react-query and handle light state at the global level, that way all we need to reference is props.